### PR TITLE
update `_stop` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ class NetFacility extends Base {
       next => { super._stop(next) },
       async () => {
         if (this.rpcServer) {
-          await this.rpcServer.end()
+          await this.rpcServer.close()
         }
 
         if (this.rpc) {


### PR DESCRIPTION
The method to stop the RPC server is close, updated the method:
- https://github.com/holepunchto/rpc/blob/775c1c0b4380a111c738e13becf2bd18ba5a634f/index.js#L318

This caused an issue where the worker using the facility was not terminating when called outside boot-js