### PR TITLE
lookup stop fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,6 @@ class NetFacility extends Base {
       this.opts.poolLinger = 300000
     }
 
-    this.opts.swarmDestroyReq ||= false
-
     this.init()
   }
 
@@ -279,7 +277,7 @@ class NetFacility extends Base {
           await this.rpc.destroy()
         }
 
-        if (this.swarm && this.opts.swarmDestroyReq) {
+        if (this.swarm) {
           await this.swarm.destroy()
         }
 


### PR DESCRIPTION
Here’s the corrected version:

1. `this.lookup.stop()` is failing because of `dht.destroy()`.
2. `this.swarm.destroy()` also calls `dht.destroy()` internally. We are moving this swarm destroy into `facs` for consistency.
3. I tested multiple calls to `this.swarm.destroy()`, and it is not causing any problems.
