### PR TITLE
cache lookup result only if some data exists

### DIFF
--- a/lib/hyperdht.lookup.js
+++ b/lib/hyperdht.lookup.js
@@ -190,7 +190,10 @@ class HyperDHTLookup {
     }
 
     const res = Array.from(set)
-    this._cache.set(ckey, res)
+    // Only cache if we have results, otherwise we might cache empty result and miss future peers
+    if (res.length > 0) {
+      this._cache.set(ckey, res)
+    }
     return res
   }
 }


### PR DESCRIPTION
Making this change here to mitigate the possible issue of caching empty list of peers on a lookup when other services were not available (e.g., we restarted other services). This will ensure that we'll reuse cached set of peers only when at least one entry exists. If the peers list for a topic is empty, we'll load fresh list from the DHT each time. This PR is related to the caching that we are doing for this: https://github.com/tetherto/wdk-ork-wrk/pull/83