### PR TITLE
Feature : Support dhtOpts from facility opts and conf

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,9 +477,13 @@ class NetFacility extends Base {
       next => { super._start(next) },
       async () => {
         const seed = await this.getSeed('seedDht')
-        const keyPair = DHT.keyPair(seed)
+        const dhtOpts = {
+          ...this.opts.dhtOpts,
+          ...this.conf.dhtOpts,
+          keyPair: DHT.keyPair(seed)
+        }
 
-        this.dht = new DHT({ keyPair })
+        this.dht = new DHT(dhtOpts)
       }
     ], cb)
   }

--- a/index.js
+++ b/index.js
@@ -478,8 +478,8 @@ class NetFacility extends Base {
       async () => {
         const seed = await this.getSeed('seedDht')
         const dhtOpts = {
-          ...this.opts.dhtOpts,
-          ...this.conf.dhtOpts,
+          ...(this.conf.dhtOpts || {}),
+          ...(this.opts.dhtOpts || {}),
           keyPair: DHT.keyPair(seed)
         }
 


### PR DESCRIPTION
# 🔀 Feature/Refactor: Support dhtOpts from facility opts and conf

> **Type:** Refactor / Improvement
> **Ticket/Issue:** N/A

---

## 📝 Description

This change ensures that `HyperDHT` is instantiated with a complete set of options by merging `this.opts.dhtOpts` and `this.conf.dhtOpts` during the `_start` phase.

Crucially, the identity configuration remains safe: the DHT key pair continues to be generated from the persisted `seedDht` value, which strictly overrides any `keyPair` or `seed` properties that might be passed inside the merged options.

---

## 🎯 Changes Made

* Combined `this.opts.dhtOpts` and `this.conf.dhtOpts` into a single configuration object.
* Passed the merged options object directly to the `HyperDHT` constructor inside `_start`.
* Ensured the key pair generated from `seedDht` takes precedence and overrides any other credentials in the configuration.

---

### Type:
* [x] refactor
* [x] improvement