### PR TITLE
fix: evict stale pooled rpc client and re-dial on closed-client error

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,11 +119,10 @@ class NetFacility extends Base {
   }
 
   /**
-   * Removes the pooled RPC client for `key` when it is already closed, so the
-   * next request re-dials. A client whose stream dies before its RPC channel
-   * opens never emits 'close', so the rpc pool never evicts it and every
-   * request to that key fails instantly with `RPC client closed` forever.
-   * @param {Buffer|string} key - peer RPC publicKey (Buffer or hex string)
+   * Evicts the pooled RPC client for `key` if it is already closed, so the
+   * next request re-dials. A client that dies before its RPC channel opens
+   * never emits 'close' and would otherwise stay pooled (and failing) forever.
+   * @param {Buffer|string} key
    */
   _evictStaleRpcClient (key) {
     const pool = this.rpc._pool
@@ -147,9 +146,8 @@ class NetFacility extends Base {
     try {
       res = await this.rpc.request(publicKey, method, payload, opts)
     } catch (err) {
-      // `RPC client closed` is thrown before anything is sent, so the request
-      // never reached the peer: evicting the stale client and re-dialing once
-      // is safe even for non-idempotent methods.
+      // Thrown before anything is sent, so evicting the stale client and
+      // re-dialing once is safe even for non-idempotent methods.
       if (err.message !== 'RPC client closed') {
         throw err
       }

--- a/index.js
+++ b/index.js
@@ -118,11 +118,44 @@ class NetFacility extends Base {
     return Buffer.from(data.toString())
   }
 
+  /**
+   * Removes the pooled RPC client for `key` when it is already closed, so the
+   * next request re-dials. A client whose stream dies before its RPC channel
+   * opens never emits 'close', so the rpc pool never evicts it and every
+   * request to that key fails instantly with `RPC client closed` forever.
+   * @param {Buffer|string} key - peer RPC publicKey (Buffer or hex string)
+   */
+  _evictStaleRpcClient (key) {
+    const pool = this.rpc._pool
+    if (!(pool instanceof Map)) {
+      return
+    }
+    const id = Buffer.isBuffer(key) ? key.toString('hex') : key
+    const ref = pool.get(id)
+    if (!ref || !ref.client || !ref.client.closed) {
+      return
+    }
+    pool.delete(id)
+    ref.destroy()
+  }
+
   async _request (key, method, data, opts) {
-    let res = await this.rpc.request(
-      Buffer.from(key, 'hex'), method,
-      this.toOutJSON(data), opts
-    )
+    const publicKey = Buffer.from(key, 'hex')
+    const payload = this.toOutJSON(data)
+
+    let res
+    try {
+      res = await this.rpc.request(publicKey, method, payload, opts)
+    } catch (err) {
+      // `RPC client closed` is thrown before anything is sent, so the request
+      // never reached the peer: evicting the stale client and re-dialing once
+      // is safe even for non-idempotent methods.
+      if (err.message !== 'RPC client closed') {
+        throw err
+      }
+      this._evictStaleRpcClient(key)
+      res = await this.rpc.request(publicKey, method, payload, opts)
+    }
 
     res = this.parseInputJSON(res)
     this.handleInputError(res)

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -140,6 +140,36 @@ test('NetFacility', async (t) => {
       t.is(facCaller.calls.clientClosed, 1)
     })
 
+    await t.test('should evict a stale pooled client and re-dial', async (t) => {
+      t.teardown(() => facCaller.resetCalls())
+
+      // Warm the pool, then wedge the pooled client into the state left by a
+      // stream that dies before its RPC channel opens: it reports closed but
+      // never emitted 'close', so the pool still holds it.
+      await net.jRequest(rpcKey, 'ping', { value: 1 })
+      const poolId = rpcKey.toString('hex')
+      const stale = net.rpc._pool.get(poolId)
+      t.ok(stale, 'client is pooled after a request')
+      stale.client._closed = true
+
+      const res = await net.jRequest(rpcKey, 'ping', { value: 42 })
+
+      t.is(res, 42, 'request succeeds via a fresh client')
+      t.not(net.rpc._pool.get(poolId), stale, 'stale client was evicted from the pool')
+    })
+
+    await t.test('should re-dial exactly once when RPC client closed persists at transport level', async (t) => {
+      const err = new Error('RPC client closed')
+      const stub = sinon.stub(net.rpc, 'request').rejects(err)
+      t.teardown(() => stub.restore())
+
+      await t.exception(
+        () => net.jRequest(rpcKey, 'ping', { value: 1 }),
+        /RPC client closed/
+      )
+      t.is(stub.callCount, 2)
+    })
+
     await t.test('autoRetry=1: should retry once on RPC client closed and succeed', async (t) => {
       t.teardown(() => facCaller.resetCalls())
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const StoreFacility = require('@tetherto/hp-svc-facs-store')
+const HyperDHT = require('hyperdht')
 const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
@@ -143,19 +144,29 @@ test('NetFacility', async (t) => {
     await t.test('should evict a stale pooled client and re-dial', async (t) => {
       t.teardown(() => facCaller.resetCalls())
 
-      // Warm the pool, then wedge the pooled client into the state left by a
-      // stream that dies before its RPC channel opens: it reports closed but
-      // never emitted 'close', so the pool still holds it.
-      await net.jRequest(rpcKey, 'ping', { value: 1 })
-      const poolId = rpcKey.toString('hex')
-      const stale = net.rpc._pool.get(poolId)
-      t.ok(stale, 'client is pooled after a request')
-      stale.client._closed = true
+      // Real trigger for the stale-client state: the server firewall rejects
+      // the first dial, killing the client stream during the capability
+      // handshake, so the pooled client never emits 'close' and would stay
+      // wedged forever without the eviction.
+      const capability = crypto.randomBytes(32)
+      let conns = 0
+      const server = net.rpc.createServer({
+        capability,
+        firewall: () => conns++ < 1
+      })
+      server.respond('ping', (req) => net.handleReply('ping', req))
+      await server.listen(HyperDHT.keyPair())
+      t.teardown(() => server.close())
 
-      const res = await net.jRequest(rpcKey, 'ping', { value: 42 })
+      const spy = sinon.spy(net.rpc, 'request')
+      t.teardown(() => spy.restore())
+
+      const res = await net.jRequest(server.publicKey, 'ping', { value: 42 }, { capability })
 
       t.is(res, 42, 'request succeeds via a fresh client')
-      t.not(net.rpc._pool.get(poolId), stale, 'stale client was evicted from the pool')
+      t.is(spy.callCount, 2, 'stale client was evicted and re-dialed once')
+      await t.exception(() => spy.firstCall.returnValue, /RPC client closed/)
+      t.is(conns, 2, 'firewall saw the rejected dial and the re-dial')
     })
 
     await t.test('should re-dial exactly once when RPC client closed persists at transport level', async (t) => {


### PR DESCRIPTION
## Context

Since July 7 our production wallet services were failing a portion of internal RPC calls with "RPC client closed", continuously for two days. The workers were healthy and the peers were reachable, yet the errors never stopped until the affected processes were restarted. Wallet creation and new-user signup failed whenever they hit one of the bad connections.

## Root cause

The rpc layer keeps one pooled connection per peer and removes it from the pool when the connection announces that it closed. There is one window where that announcement never comes: if the connection dies while its handshake is still in progress, the pooled entry ends up permanently closed but silent. From then on every call to that peer picks up the same dead connection and fails instantly. The pool's idle cleanup cannot collect it either, because steady traffic keeps resetting the idle timer. Any short network blip can create these zombie connections, and they never recover on their own.

## Changes

- A request that lands on a dead pooled connection now drops it and dials a fresh one, once, on the normal request path. Callers need no changes.
- The failure fires before anything is sent to the peer, so the single retry cannot duplicate a delivered request and is safe for write operations.
- Existing opt-in retry behavior for remote errors and mid-flight disconnects is unchanged.
- Tests cover the zombie-connection recovery and guarantee only a single re-dial attempt.