### PR TITLE
fix: harden allowLocal firewall against spoofed peer addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,8 +314,8 @@ class NetFacility extends Base {
    * Builds a `@hyperswarm/rpc` firewall predicate. The returned function returns
    * `true` to reject a peer and `false` to allow it.
    * @param {Array<Buffer|string>|null} allowed - allow-list of peer publicKeys; `null` disables filtering
-   * @param {boolean} [allowLocal=false] - additionally allow peers connecting from the host's local IPv4
-   * @returns {function(Buffer, Object): boolean}
+   * @param {boolean} [allowLocal=false] - additionally allow peers whose observed remote address is the host's local IPv4
+   * @returns {function(Buffer, Object, {host: string, port: number}=): boolean} predicate `(remotePublicKey, remoteHandshakePayload, remoteAddress)`; the allowLocal check matches the DHT-observed `remoteAddress`, not the peer-supplied handshake payload
    */
   buildFirewall (allowed, allowLocal = false) {
     // convert keys to Buffer if string
@@ -324,12 +324,14 @@ class NetFacility extends Base {
     // if firewall enabled, allow from local ip
     const localIp = allowLocal ? this.getLocalIPAddress() : null
 
-    return (remotePublicKey, remoteHandshakePayload) => {
+    return (remotePublicKey, remoteHandshakePayload, remoteAddress) => {
       if (allowed && !libKeys.checkAllowList(allowed, remotePublicKey)) {
-        if (allowLocal && localIp && remoteHandshakePayload?.addresses4) {
-          for (const remoteHost of remoteHandshakePayload.addresses4) {
-            if (remoteHost.host === localIp) return false
-          }
+        // allowLocal only trusts the address the DHT observed the peer connect
+        // from (remoteAddress); never remoteHandshakePayload.addresses4, which the
+        // remote peer sets freely and could use to claim a local IP to bypass the
+        // allow-list.
+        if (allowLocal && localIp && remoteAddress?.host === localIp) {
+          return false
         }
 
         return true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/hp-svc-facs-net",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/hp-svc-facs-net",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitfinex/bfx-facs-base": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/hp-svc-facs-net",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "description": "Holepunch SVC Facility RPC",
   "author": {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -356,4 +356,54 @@ test('NetFacility', async (t) => {
       t.is(spy.thirdCall.args[1], false)
     })
   })
+
+  await t.test('buildFirewall', async (t) => {
+    const allowedKey = crypto.randomBytes(32)
+    const strangerKey = crypto.randomBytes(32)
+    const localIp = '192.168.1.50'
+    const remoteAddr = { host: '203.0.113.7', port: 5000 }
+
+    // The predicate returns `true` to REJECT a peer and `false` to ALLOW it.
+    await t.test('rejects a peer that is not on the allow-list', async (t) => {
+      const firewall = net.buildFirewall([allowedKey], false)
+      t.is(firewall(strangerKey, {}, remoteAddr), true)
+    })
+
+    await t.test('allows a peer that is on the allow-list', async (t) => {
+      const firewall = net.buildFirewall([allowedKey], false)
+      t.is(firewall(allowedKey, {}, remoteAddr), false)
+    })
+
+    await t.test('allows everyone when no allow-list is configured', async (t) => {
+      const firewall = net.buildFirewall(null, false)
+      t.is(firewall(strangerKey, {}, remoteAddr), false)
+    })
+
+    await t.test('allowLocal allows a non-allow-listed peer whose observed address is local', async (t) => {
+      const stub = sinon.stub(net, 'getLocalIPAddress').returns(localIp)
+      t.teardown(() => stub.restore())
+
+      const firewall = net.buildFirewall([allowedKey], true)
+      t.is(firewall(strangerKey, {}, { host: localIp, port: 49152 }), false)
+    })
+
+    await t.test('allowLocal ignores a spoofed handshake addresses4 (WDK-1599 bypass)', async (t) => {
+      const stub = sinon.stub(net, 'getLocalIPAddress').returns(localIp)
+      t.teardown(() => stub.restore())
+
+      const firewall = net.buildFirewall([allowedKey], true)
+      // Attacker claims the host's local IP in the peer-controlled handshake
+      // payload, but actually connects from a remote address. Must be rejected.
+      const spoofedPayload = { addresses4: [{ host: localIp, port: 1 }] }
+      t.is(firewall(strangerKey, spoofedPayload, remoteAddr), true)
+    })
+
+    await t.test('allowLocal rejects a non-allow-listed peer when no observed address is provided', async (t) => {
+      const stub = sinon.stub(net, 'getLocalIPAddress').returns(localIp)
+      t.teardown(() => stub.restore())
+
+      const firewall = net.buildFirewall([allowedKey], true)
+      t.is(firewall(strangerKey, { addresses4: [{ host: localIp }] }, undefined), true)
+    })
+  })
 })


### PR DESCRIPTION
## Context

The network facility firewall has an optional mode that, on top of an allow-list, also admits peers connecting from the host's own local machine. That local check trusted address information supplied by the connecting peer itself, so a remote peer already holding the shared connection secret could claim to be local and slip past the allow-list. Impact is low (the peer still needs the shared capability key) and no current deployment enables this mode, but it is a real allow-list bypass in a shared library.

Ticket: [Bug: buildFirewall allowLocal trusts remote-controlled handshake addresses4 (allow-list bypass)](https://app.asana.com/1/45238840754660/project/1210540875949204/task/1216355906086148) (WDK-1599)

## Changes

- The local-peer exemption now relies on the address the network layer actually observed the connection coming from, not on any address the peer declares about itself.
- A peer that is not on the allow-list can no longer gain access by claiming a local address.
- Genuinely local peers keep connecting as before.
- Added unit tests for the allow-list behaviour, the local-peer path, and the spoofed-address case.

## Why

The observed connection address cannot be forged by the peer the way a self-declared address can, so it is the correct signal for deciding whether a connection is local. This keeps the local-peer convenience while closing the bypass.