### PR TITLE
fix: remove spoofable allowLocal option from RPC firewall

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const Base = require('@bitfinex/bfx-facs-base')
 const libKeys = require('hyper-cmd-lib-keys')
 const DHT = require('hyperdht')
 const Hyperswarm = require('hyperswarm')
-const os = require('os')
 const { setTimeout: sleep } = require('timers/promises')
 
 const HyperDHTLookup = require('./lib/hyperdht.lookup')
@@ -314,41 +313,19 @@ class NetFacility extends Base {
    * Builds a `@hyperswarm/rpc` firewall predicate. The returned function returns
    * `true` to reject a peer and `false` to allow it.
    * @param {Array<Buffer|string>|null} allowed - allow-list of peer publicKeys; `null` disables filtering
-   * @param {boolean} [allowLocal=false] - additionally allow peers connecting from the host's local IPv4
    * @returns {function(Buffer, Object): boolean}
    */
-  buildFirewall (allowed, allowLocal = false) {
+  buildFirewall (allowed) {
     // convert keys to Buffer if string
     allowed = allowed?.map(k => typeof k === 'string' ? Buffer.from(k, 'hex') : k)
 
-    // if firewall enabled, allow from local ip
-    const localIp = allowLocal ? this.getLocalIPAddress() : null
-
-    return (remotePublicKey, remoteHandshakePayload) => {
+    return (remotePublicKey) => {
       if (allowed && !libKeys.checkAllowList(allowed, remotePublicKey)) {
-        if (allowLocal && localIp && remoteHandshakePayload?.addresses4) {
-          for (const remoteHost of remoteHandshakePayload.addresses4) {
-            if (remoteHost.host === localIp) return false
-          }
-        }
-
         return true
       }
 
       return false
     }
-  }
-
-  /**
-   * @returns {string} primary non-internal IPv4 address of the host, or '127.0.0.1' as fallback
-   */
-  getLocalIPAddress () {
-    for (const devices of Object.values(os.networkInterfaces())) {
-      const device = devices.find(d => d.family === 'IPv4' && d.address !== '127.0.0.1' && !d.internal)
-      if (device) return device.address
-    }
-
-    return '127.0.0.1'
   }
 
   /**
@@ -397,13 +374,16 @@ class NetFacility extends Base {
 
     await this.startRpc(keyPair)
 
-    const { allow, allowReadOnly, allowLocal } = this.conf
+    const { allow, allowReadOnly } = this.conf
+    if (this.conf.allowLocal) {
+      console.warn('WARNING: net facility "allowLocal" option was removed. it is now ignored. Use the "allow" public-key allowlist instead.')
+    }
     const allowedPeers = (allow || allowReadOnly)
       ? [...(allow || []), ...(allowReadOnly || [])]
       : null
 
     const server = this.rpc.createServer({
-      firewall: this.buildFirewall(allowedPeers, allowLocal),
+      firewall: this.buildFirewall(allowedPeers),
       ...serverOpts
     })
 

--- a/tests/firewall.test.js
+++ b/tests/firewall.test.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const StoreFacility = require('@tetherto/hp-svc-facs-store')
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const sinon = require('sinon')
+const test = require('brittle')
+const { EventEmitter } = require('events')
+
+const NetFacility = require('../index')
+
+const facCtx = { env: 'test' }
+
+const newCaller = () => new class FacCaller extends EventEmitter {
+  constructor () {
+    super()
+    this.ctx = { root: __dirname }
+  }
+}()
+
+test('buildFirewall', async (t) => {
+  const net = new NetFacility(newCaller(), { ns: 'r0', label: 'r0', root: __dirname }, facCtx)
+
+  const keyA = crypto.randomBytes(32)
+  const keyB = crypto.randomBytes(32)
+
+  await t.test('should allow any peer when allowed list is null', async (t) => {
+    const fw = net.buildFirewall(null)
+    t.is(fw(keyA), false)
+    t.is(fw(keyB), false)
+  })
+
+  await t.test('should allow listed peers and reject others', async (t) => {
+    const fw = net.buildFirewall([keyA])
+    t.is(fw(keyA), false)
+    t.is(fw(keyB), true)
+  })
+
+  await t.test('should coerce hex string keys in allowed list', async (t) => {
+    const fw = net.buildFirewall([keyA.toString('hex')])
+    t.is(fw(keyA), false)
+    t.is(fw(keyB), true)
+  })
+
+  await t.test('should reject unlisted peers claiming local addresses in handshake payload', async (t) => {
+    const fw = net.buildFirewall([keyA])
+    const spoofedPayload = {
+      addresses4: [{ host: '127.0.0.1' }, { host: '192.168.1.1' }, { host: '10.0.0.1' }]
+    }
+    t.is(fw(keyB, spoofedPayload), true)
+  })
+})
+
+test('startRpcServer with legacy allowLocal conf', async (t) => {
+  t.timeout(300000)
+
+  const facCaller = newCaller()
+  const storeDir = path.join(__dirname, 'store-firewall')
+  if (fs.existsSync(storeDir)) {
+    fs.rmSync(storeDir, { recursive: true })
+  }
+
+  const store = new StoreFacility(facCaller, { ns: 's0', label: 's0', storeDir, root: __dirname }, facCtx)
+  const net = new NetFacility(facCaller, { ns: 'r0', label: 'r0', fac_store: store, root: __dirname }, facCtx)
+
+  t.teardown(async () => {
+    await Promise.all([
+      new Promise((resolve) => store.stop(resolve)),
+      new Promise((resolve) => net.stop(resolve))
+    ])
+    fs.rmSync(storeDir, { recursive: true })
+  })
+
+  await new Promise((resolve, reject) => store.start((err) => err ? reject(err) : resolve()))
+  await new Promise((resolve, reject) => net.start((err) => err ? reject(err) : resolve()))
+
+  net.conf.allowLocal = true
+  const warnSpy = sinon.spy(console, 'warn')
+  t.teardown(() => warnSpy.restore())
+
+  await net.startRpcServer()
+
+  t.ok(net.rpcServer, 'rpc server started')
+  t.ok(
+    warnSpy.getCalls().some(c => String(c.args[0]).includes('allowLocal')),
+    'deprecation warning logged'
+  )
+})


### PR DESCRIPTION
## Problem

The security audit found that the `allowLocal` firewall option is bypassable. `buildFirewall` decides whether a peer is "local" by inspecting `remoteHandshakePayload.addresses4`, which is entirely client-controlled — a remote attacker can claim a local IP in the handshake payload and bypass the allowlist. (The `clientAddress` argument is equally spoofable.) IP-based firewall rules over HyperDHT cannot be made reliable; only public-key allowlists can.

## Fix

- Remove the `allowLocal` parameter and the local-IP bypass branch from `buildFirewall`; the predicate now rejects a peer iff an allowlist is configured and `remotePublicKey` is not in it.
- Remove `getLocalIPAddress` (only caller was the bypass branch) and the `os` require.
- Warn-and-ignore semantics for stale configs: if `allowLocal` is still present in the net facility conf, `startRpcServer` logs a deprecation warning via `console.warn` and ignores it. Peer filtering relies solely on the existing `allow` / `allowReadOnly` public-key allowlists.
- No version bump — releases are cut via GitHub Actions.

## Testing

New `tests/firewall.test.js` adds first-time coverage of `buildFirewall`:
- `null` allowlist still allows everything (unchanged default behavior)
- listed keys allowed, unlisted rejected; hex-string keys coerced to Buffers
- regression: an unlisted peer claiming local addresses (`addresses4: [{host: '127.0.0.1'}, ...]`) is still rejected
- `startRpcServer` with legacy `allowLocal: true` conf boots, logs the warning, and installs a key-only firewall

Full suite: `npm test` → 4/4 tests, 87/87 asserts, lint clean.